### PR TITLE
Bug-000 Remove repeated mouseclick events

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -158,57 +158,59 @@ bool Game::init(std::string cfg_file_path){
 }
 
 void Game::handleEvents(){
-	SDL_PollEvent(&m_event);
-	if(m_event.type==SDL_EVENT_QUIT) m_running = false;
+	while (SDL_PollEvent(&m_event)){
+		if(m_event.type==SDL_QUIT) m_running = false;
 
-	//all code below is for what happens if you press (any) mouse button -----------
-	if(m_event.button.down==true){ 
-		int r = (int) m_event.button.y / (int)cell[0][0].getSize();
-		int c = (int) m_event.button.x / (int)cell[0][0].getSize();
-		SDL_Log("Cell clicked: %i, %i", r, c);
+		//all code below is for what happens if you press (any) mouse button -----------
+		if(m_event.type==SDL_MOUSEBUTTONDOWN){
+			int r = (int) m_event.button.y / (int)cell[0][0].getSize();
+			int c = (int) m_event.button.x / (int)cell[0][0].getSize();
+			SDL_Log("Cell clicked: %i, %i", r, c);
 		
-		//sets cell to alive or dead
-		cell[r][c].setAlive(!cell[r][c].getAlive());
-		/*
-		//if cell is alive add it to live_list
-		if(cell[r][c].getAlive()){
-			//checks if cell is already on the list
-			bool found = false;
-			for(int i=0; i<live_list.size(); i++){
-				if(live_list[i]==cell[r][c]){
-					found = true;
-					break;
+			//sets cell to alive or dead
+			cell[r][c].setAlive(!cell[r][c].getAlive());
+			/*
+			//if cell is alive add it to live_list
+			if(cell[r][c].getAlive()){
+				//checks if cell is already on the list
+				bool found = false;
+				for(int i=0; i<live_list.size(); i++){
+					if(live_list[i]==cell[r][c]){
+						found = true;
+						break;
+					}
+				}
+				//if it's not on the list, add it
+				if(!found){
+					live_list.push_back(cell[r][c]);	
 				}
 			}
-			//if it's not on the list, add it
-			if(!found){
-				live_list.push_back(cell[r][c]);	
-			}
-		}
-		//if cell isn't alive, remove it from the live list
-		else{
-			//checks if cell is on the list
-			for(int i=0; i<live_list.size(); i++){
-				//if it is, erase it
-				if(live_list[i]==cell[r][c]){
-					live_list.erase(live_list.begin() + i);
-					break;
+			//if cell isn't alive, remove it from the live list
+			else{
+				//checks if cell is on the list
+				for(int i=0; i<live_list.size(); i++){
+					//if it is, erase it
+					if(live_list[i]==cell[r][c]){
+						live_list.erase(live_list.begin() + i);
+						break;
+					}
 				}
 			}
+			*/
 		}
-		*/
+		//if you press enter it should step the simulation
+		if(m_event.type == SDL_KEYDOWN){
+			switch(m_event.key.keysym.sym){
+				case SDLK_SPACE:
+					m_step = true;
+					break;
+			}
+		}
 	}
 	//---------------------------------------------------------------------
 
-	//if you press enter it should step the simulation
-	if(m_event.key.type == SDL_EVENT_KEY_DOWN){
-		switch(m_event.key.key){
-			case SDLK_SPACE:
-				m_step = true;
-				break;
-		}
-	}
 }
+
 
 void Game::update(){
 


### PR DESCRIPTION
When testing on Devuan GNU/Linux (gcc 10.2.1), I experienced a runtime bug where the *same mouseclick was processed several times in a row.* Based on my knowledge writing games in SDL2 in the past, I wrapped the PollEvent call inside a while-loop in order to resolve it -- and sure enough, it worked! On my machine, each mouseclick was registered "once and only once," no matter how long the mouse button was "held down."

But, this update does come with a disclaimer. I have modified this code to use my local libraries, which are SDL2 libraries rather than SDL3. Thus, if this change does not work (or does not noticeably change any of the runtime logs) on *your* machine, please do not merge it!! It could be an outdated approach. On that note, I might simply add a different branch to store all my "tweaks for SDL2," but since that's an older/outdated library, I may or may not actually submit a PR for it here.

In any case, I am obliged to say, thank you so much for the opportunity. It was great to "scratch the itch" and try running another SDL game after so many years away from that framework.